### PR TITLE
Add API controllers and resources for jobs and notes

### DIFF
--- a/backend/app/Http/Controllers/JobController.php
+++ b/backend/app/Http/Controllers/JobController.php
@@ -2,64 +2,144 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\JobIndexRequest;
+use App\Http\Requests\JobStoreRequest;
+use App\Http\Requests\JobUpdateRequest;
+use App\Http\Resources\JobResource;
 use App\Models\Job;
-use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
 
 class JobController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(JobIndexRequest $request): AnonymousResourceCollection
     {
-        //
-    }
+        $filters = $request->validated();
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
+        $query = Job::query()
+            ->with([
+                'status',
+                'notes' => static function (Builder $query): void {
+                    $query->latest('created_at');
+                },
+            ]);
+
+        if (! empty($filters['status'])) {
+            $query->forStatus($filters['status']);
+        }
+
+        if (! empty($filters['job_status_id'])) {
+            $query->where('job_status_id', $filters['job_status_id']);
+        }
+
+        if (! empty($filters['search'])) {
+            $search = $filters['search'];
+            $query->where(static function (Builder $builder) use ($search): void {
+                $builder->where('title', 'like', "%{$search}%")
+                    ->orWhere('company', 'like', "%{$search}%")
+                    ->orWhere('location', 'like', "%{$search}%");
+            });
+        }
+
+        $sort = $filters['sort'] ?? 'created_at';
+        $direction = $filters['direction'] ?? 'desc';
+
+        $query->orderBy($sort, $direction);
+
+        $perPage = $filters['per_page'] ?? 15;
+
+        $jobs = $query->paginate($perPage)->appends($request->query());
+
+        return JobResource::collection($jobs);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(JobStoreRequest $request): Response
     {
-        //
+        $data = $request->validated();
+
+        $job = new Job();
+        $job->title = $data['title'];
+        $job->company = $data['company'];
+        $job->location = $data['location'] ?? null;
+        $job->job_status_id = $data['job_status_id'];
+        $job->applied_at = $data['applied_at'] ?? null;
+        $job->posting_url = $data['posting_url'] ?? null;
+        $job->salary = $data['salary'] ?? null;
+        $job->save();
+
+        $job->load(['status', 'notes']);
+
+        return (new JobResource($job))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(Job $job)
+    public function show(Job $job): JobResource
     {
-        //
-    }
+        $job->load(['status', 'notes']);
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(Job $job)
-    {
-        //
+        return new JobResource($job);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, Job $job)
+    public function update(JobUpdateRequest $request, Job $job): JobResource
     {
-        //
+        $data = $request->validated();
+
+        if (array_key_exists('title', $data)) {
+            $job->title = $data['title'];
+        }
+
+        if (array_key_exists('company', $data)) {
+            $job->company = $data['company'];
+        }
+
+        if (array_key_exists('location', $data)) {
+            $job->location = $data['location'];
+        }
+
+        if (array_key_exists('job_status_id', $data)) {
+            $job->job_status_id = $data['job_status_id'];
+        }
+
+        if (array_key_exists('applied_at', $data)) {
+            $job->applied_at = $data['applied_at'];
+        }
+
+        if (array_key_exists('posting_url', $data)) {
+            $job->posting_url = $data['posting_url'];
+        }
+
+        if (array_key_exists('salary', $data)) {
+            $job->salary = $data['salary'];
+        }
+
+        $job->save();
+
+        $job->load(['status', 'notes']);
+
+        return new JobResource($job);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(Job $job)
+    public function destroy(Job $job): Response
     {
-        //
+        $job->delete();
+
+        return response()->noContent();
     }
 }

--- a/backend/app/Http/Controllers/JobNoteController.php
+++ b/backend/app/Http/Controllers/JobNoteController.php
@@ -2,64 +2,136 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\JobNoteIndexRequest;
+use App\Http\Requests\JobNoteStoreRequest;
+use App\Http\Requests\JobNoteUpdateRequest;
+use App\Http\Resources\JobNoteResource;
+use App\Models\Job;
 use App\Models\JobNote;
-use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
 
 class JobNoteController extends Controller
 {
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index(Job $job, JobNoteIndexRequest $request): AnonymousResourceCollection
     {
-        //
-    }
+        $filters = $request->validated();
 
-    /**
-     * Show the form for creating a new resource.
-     */
-    public function create()
-    {
-        //
+        $query = $job->notes()
+            ->with(['job.status'])
+            ->when(
+                ! empty($filters['search']),
+                static function (Builder $builder) use ($filters): void {
+                    $builder->where('body', 'like', "%{$filters['search']}%");
+                }
+            )
+            ->when(
+                array_key_exists('has_reminder', $filters) && $filters['has_reminder'] !== null,
+                static function (Builder $builder) use ($filters): void {
+                    if ($filters['has_reminder']) {
+                        $builder->whereNotNull('reminder_at');
+                    } else {
+                        $builder->whereNull('reminder_at');
+                    }
+                }
+            );
+
+        $sort = $filters['sort'] ?? 'created_at';
+        $direction = $filters['direction'] ?? 'desc';
+
+        $query->orderBy($sort, $direction);
+
+        $perPage = $filters['per_page'] ?? 15;
+
+        $notes = $query->paginate($perPage)->appends($request->query());
+
+        return JobNoteResource::collection($notes);
     }
 
     /**
      * Store a newly created resource in storage.
      */
-    public function store(Request $request)
+    public function store(Job $job, JobNoteStoreRequest $request): Response
     {
-        //
+        $data = $request->validated();
+
+        $note = new JobNote();
+        $note->job()->associate($job);
+        $note->body = $data['body'];
+        $note->reminder_at = $data['reminder_at'] ?? null;
+        $note->created_by = $data['created_by'] ?? $request->user()?->getKey();
+        $note->save();
+
+        $note->load(['job.status']);
+
+        return (new JobNoteResource($note))
+            ->response()
+            ->setStatusCode(Response::HTTP_CREATED);
     }
 
     /**
      * Display the specified resource.
      */
-    public function show(JobNote $jobNote)
+    public function show(Job $job, JobNote $jobNote): JobNoteResource
     {
-        //
-    }
+        $this->ensureJobNoteBelongsToJob($job, $jobNote);
 
-    /**
-     * Show the form for editing the specified resource.
-     */
-    public function edit(JobNote $jobNote)
-    {
-        //
+        $jobNote->load(['job.status']);
+
+        return new JobNoteResource($jobNote);
     }
 
     /**
      * Update the specified resource in storage.
      */
-    public function update(Request $request, JobNote $jobNote)
+    public function update(Job $job, JobNoteUpdateRequest $request, JobNote $jobNote): JobNoteResource
     {
-        //
+        $this->ensureJobNoteBelongsToJob($job, $jobNote);
+
+        $data = $request->validated();
+
+        if (array_key_exists('body', $data)) {
+            $jobNote->body = $data['body'];
+        }
+
+        if (array_key_exists('reminder_at', $data)) {
+            $jobNote->reminder_at = $data['reminder_at'];
+        }
+
+        if (array_key_exists('created_by', $data)) {
+            $jobNote->created_by = $data['created_by'];
+        }
+
+        $jobNote->save();
+
+        $jobNote->load(['job.status']);
+
+        return new JobNoteResource($jobNote);
     }
 
     /**
      * Remove the specified resource from storage.
      */
-    public function destroy(JobNote $jobNote)
+    public function destroy(Job $job, JobNote $jobNote): Response
     {
-        //
+        $this->ensureJobNoteBelongsToJob($job, $jobNote);
+
+        $jobNote->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Ensure the note belongs to the provided job.
+     */
+    protected function ensureJobNoteBelongsToJob(Job $job, JobNote $jobNote): void
+    {
+        if ($jobNote->job_id !== $job->getKey()) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
     }
 }

--- a/backend/app/Http/Requests/JobIndexRequest.php
+++ b/backend/app/Http/Requests/JobIndexRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobIndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['nullable', 'string'],
+            'job_status_id' => ['nullable', 'integer', 'exists:job_statuses,id'],
+            'search' => ['nullable', 'string'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'sort' => ['nullable', 'in:created_at,applied_at,title,company'],
+            'direction' => ['nullable', 'in:asc,desc'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/JobNoteIndexRequest.php
+++ b/backend/app/Http/Requests/JobNoteIndexRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobNoteIndexRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'search' => ['nullable', 'string'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'sort' => ['nullable', 'in:created_at,reminder_at'],
+            'direction' => ['nullable', 'in:asc,desc'],
+            'has_reminder' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/JobNoteStoreRequest.php
+++ b/backend/app/Http/Requests/JobNoteStoreRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobNoteStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string'],
+            'reminder_at' => ['nullable', 'date'],
+            'created_by' => ['nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/JobNoteUpdateRequest.php
+++ b/backend/app/Http/Requests/JobNoteUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobNoteUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['sometimes', 'string'],
+            'reminder_at' => ['sometimes', 'nullable', 'date'],
+            'created_by' => ['sometimes', 'nullable', 'integer', 'exists:users,id'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/JobStoreRequest.php
+++ b/backend/app/Http/Requests/JobStoreRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobStoreRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'company' => ['required', 'string', 'max:255'],
+            'location' => ['nullable', 'string', 'max:255'],
+            'job_status_id' => ['required', 'integer', 'exists:job_statuses,id'],
+            'applied_at' => ['nullable', 'date'],
+            'posting_url' => ['nullable', 'url', 'max:2048'],
+            'salary' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/JobUpdateRequest.php
+++ b/backend/app/Http/Requests/JobUpdateRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class JobUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'string', 'max:255'],
+            'company' => ['sometimes', 'string', 'max:255'],
+            'location' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'job_status_id' => ['sometimes', 'integer', 'exists:job_statuses,id'],
+            'applied_at' => ['sometimes', 'nullable', 'date'],
+            'posting_url' => ['sometimes', 'nullable', 'url', 'max:2048'],
+            'salary' => ['sometimes', 'nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/backend/app/Http/Resources/JobNoteResource.php
+++ b/backend/app/Http/Resources/JobNoteResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\JobNote
+ */
+class JobNoteResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'job_id' => $this->job_id,
+            'body' => $this->body,
+            'reminder_at' => $this->reminder_at?->toISOString(),
+            'created_by' => $this->created_by,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+            'job' => new JobResource($this->whenLoaded('job')),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/JobResource.php
+++ b/backend/app/Http/Resources/JobResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\Job
+ */
+class JobResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'company' => $this->company,
+            'location' => $this->location,
+            'salary' => $this->salary,
+            'applied_at' => $this->applied_at?->toISOString(),
+            'posting_url' => $this->posting_url,
+            'job_status_id' => $this->job_status_id,
+            'status' => new JobStatusResource($this->whenLoaded('status')),
+            'notes' => JobNoteResource::collection($this->whenLoaded('notes')),
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Http/Resources/JobStatusResource.php
+++ b/backend/app/Http/Resources/JobStatusResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\JobStatus
+ */
+class JobStatusResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+            'sort_order' => $this->sort_order,
+            'is_default' => $this->is_default,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- implement the job controller with form request validation, filtering, pagination, and resource responses
- add a nested job note controller with validation, relationship checks, and paginated resource output
- introduce dedicated form requests and API resources for jobs, notes, and statuses to standardize API payloads

## Testing
- php artisan test *(fails: vendor/autoload.php missing in repository checkout)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0c9768788325abf1456aca05300a