### PR TITLE
Add Kanban board drag-and-drop experience

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -148,6 +148,7 @@
   gap: 2rem;
   padding: 2.5rem 3rem;
   background: var(--color-background);
+  min-height: 0;
 }
 
 .workspace__header {
@@ -210,7 +211,10 @@
   border: 1px solid var(--color-border);
   padding: 1.5rem;
   display: flex;
-  align-items: stretch;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .kanban__placeholder {
@@ -225,6 +229,156 @@
   text-align: center;
   font-size: 0.95rem;
   line-height: 1.5;
+}
+
+.kanban__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  gap: 1rem;
+}
+
+.kanban__columns {
+  flex: 1;
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.kanban__columns::-webkit-scrollbar {
+  height: 8px;
+}
+
+.kanban__columns::-webkit-scrollbar-thumb {
+  background-color: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.kanban__column {
+  background: var(--color-background);
+  border-radius: 1.25rem;
+  border: 1px solid var(--color-border);
+  padding: 1.25rem;
+  min-width: 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.kanban__column--over {
+  border-color: var(--color-primary);
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.15);
+}
+
+.kanban__column-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.kanban__column-header h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.kanban__column-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.kanban__column-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 4rem;
+}
+
+.kanban__empty-column {
+  margin: 0;
+  padding: 1rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 1rem;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  background: rgba(148, 163, 184, 0.12);
+  text-align: center;
+}
+
+.kanban__empty-board {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.kanban__card {
+  background: var(--color-surface);
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  padding: 1rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 0.75rem;
+  cursor: grab;
+  transition: box-shadow 160ms ease, transform 160ms ease, border-color 160ms ease;
+}
+
+.kanban__card:active {
+  cursor: grabbing;
+}
+
+.kanban__card--dragging {
+  opacity: 0.7;
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
+  border-color: var(--color-primary);
+}
+
+.kanban__card-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.kanban__card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.kanban__card-company {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.kanban__card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.kanban__card-meta span::before {
+  content: '•';
+  margin-right: 0.35rem;
+}
+
+.kanban__card-meta span:first-of-type::before {
+  content: '';
+  margin-right: 0;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import './App.css'
+import { KanbanBoard } from './components/KanbanBoard'
 
 export default function App() {
   return (
@@ -45,9 +46,7 @@ export default function App() {
         </header>
 
         <section className="kanban" aria-label="Kanban board">
-          <div className="kanban__placeholder">
-            Drag-and-drop columns and cards will appear here once configured.
-          </div>
+          <KanbanBoard />
         </section>
       </div>
     </div>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -1,0 +1,47 @@
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import type { JobStatus, Job } from '../types'
+import { JobCard } from './JobCard'
+
+interface ColumnProps {
+  status: JobStatus
+  jobs: Job[]
+}
+
+export const Column = ({ status, jobs }: ColumnProps) => {
+  const { isOver, setNodeRef } = useDroppable({
+    id: `column-${status.id}`,
+    data: {
+      type: 'column',
+      statusId: status.id,
+    },
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`kanban__column${isOver ? ' kanban__column--over' : ''}`}
+      role="listitem"
+      aria-label={`${status.name} column`}
+    >
+      <header className="kanban__column-header">
+        <h3>{status.name}</h3>
+        <span className="kanban__column-count">{jobs.length}</span>
+      </header>
+
+      <SortableContext
+        id={`column-sortable-${status.id}`}
+        items={jobs.map((job) => job.id.toString())}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="kanban__column-list">
+          {jobs.length > 0 ? (
+            jobs.map((job) => <JobCard key={job.id} job={job} />)
+          ) : (
+            <p className="kanban__empty-column">No jobs in this stage yet.</p>
+          )}
+        </div>
+      </SortableContext>
+    </div>
+  )
+}

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -1,0 +1,45 @@
+import { CSS } from '@dnd-kit/utilities'
+import { useSortable } from '@dnd-kit/sortable'
+import type { CSSProperties } from 'react'
+import type { Job } from '../types'
+
+interface JobCardProps {
+  job: Job
+}
+
+export const JobCard = ({ job }: JobCardProps) => {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: job.id.toString(),
+    data: {
+      type: 'job',
+      jobId: job.id,
+      statusId: job.job_status_id,
+    },
+  })
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  return (
+    <article
+      ref={setNodeRef}
+      style={style}
+      className={`kanban__card${isDragging ? ' kanban__card--dragging' : ''}`}
+      aria-label={`${job.title} at ${job.company}`}
+      {...attributes}
+      {...listeners}
+    >
+      <header className="kanban__card-header">
+        <h4 className="kanban__card-title">{job.title}</h4>
+        <p className="kanban__card-company">{job.company}</p>
+      </header>
+
+      <div className="kanban__card-meta">
+        {job.location && <span>{job.location}</span>}
+        {job.salary && <span>{job.salary}</span>}
+      </div>
+    </article>
+  )
+}

--- a/frontend/src/components/KanbanBoard.tsx
+++ b/frontend/src/components/KanbanBoard.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from 'react'
+import { useDndMonitor } from '@dnd-kit/core'
+import { Column } from './Column'
+import { useJobStatuses } from '../hooks/useJobStatuses'
+import { useJobs } from '../hooks/useJobs'
+import { useUpdateJobStatus } from '../hooks/useUpdateJobStatus'
+
+type DragData = {
+  type: 'job'
+  jobId: number
+  statusId: number
+}
+
+type DroppableData = {
+  type: 'column' | 'job'
+  statusId: number
+}
+
+export const KanbanBoard = () => {
+  const jobStatusesQuery = useJobStatuses()
+  const jobsQuery = useJobs()
+  const updateJobStatus = useUpdateJobStatus()
+
+  const statuses = jobStatusesQuery.data ?? []
+  const jobs = jobsQuery.data?.data ?? []
+
+  const columns = useMemo(
+    () =>
+      statuses.map((status) => ({
+        status,
+        jobs: jobs.filter((job) => job.job_status_id === status.id),
+      })),
+    [statuses, jobs],
+  )
+
+  useDndMonitor({
+    onDragEnd: (event) => {
+      const activeData = event.active.data.current as DragData | undefined
+      const overData = event.over?.data.current as DroppableData | undefined
+
+      if (!activeData || activeData.type !== 'job' || !event.over) {
+        return
+      }
+
+      const nextStatusId = overData?.statusId
+
+      if (!nextStatusId || nextStatusId === activeData.statusId) {
+        return
+      }
+
+      updateJobStatus.mutate({
+        jobId: activeData.jobId,
+        job_status_id: nextStatusId,
+      })
+    },
+  })
+
+  if (jobStatusesQuery.isLoading || jobsQuery.isLoading) {
+    return <div className="kanban__placeholder">Loading your pipeline…</div>
+  }
+
+  if (jobStatusesQuery.isError || jobsQuery.isError) {
+    return (
+      <div className="kanban__placeholder" role="alert">
+        We ran into a problem loading your applications. Please try again shortly.
+      </div>
+    )
+  }
+
+  if (statuses.length === 0) {
+    return (
+      <div className="kanban__placeholder">
+        No statuses are configured yet. Create statuses in the dashboard to start tracking jobs.
+      </div>
+    )
+  }
+
+  const hasJobs = jobs.length > 0
+
+  return (
+    <div className="kanban__content">
+      <div className="kanban__columns" role="list">
+        {columns.map(({ status, jobs: statusJobs }) => (
+          <Column key={status.id} status={status} jobs={statusJobs} />
+        ))}
+      </div>
+
+      {!hasJobs && (
+        <p className="kanban__empty-board">
+          No job applications yet. Add an opportunity to see it appear on this board.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useJobStatuses.ts
+++ b/frontend/src/hooks/useJobStatuses.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { get } from '../api/client'
+import type { JobStatus } from '../types'
+
+const JOB_STATUSES_QUERY_KEY = ['job-statuses'] as const
+
+export const useJobStatuses = () =>
+  useQuery({
+    queryKey: JOB_STATUSES_QUERY_KEY,
+    queryFn: () => get<JobStatus[]>('/job-statuses'),
+    select: (statuses) => [...statuses].sort((a, b) => a.sort_order - b.sort_order),
+    staleTime: 5 * 60 * 1000,
+  })
+
+export type UseJobStatusesResult = ReturnType<typeof useJobStatuses>

--- a/frontend/src/hooks/useJobs.ts
+++ b/frontend/src/hooks/useJobs.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import { get } from '../api/client'
+import type { Job, PaginatedResponse } from '../types'
+
+const JOBS_QUERY_KEY = ['jobs'] as const
+
+const DEFAULT_PAGE_SIZE = 100
+
+export const useJobs = () =>
+  useQuery({
+    queryKey: JOBS_QUERY_KEY,
+    queryFn: () => get<PaginatedResponse<Job>>('/jobs', { params: { per_page: DEFAULT_PAGE_SIZE } }),
+    staleTime: 30 * 1000,
+  })
+
+export type UseJobsResult = ReturnType<typeof useJobs>
+export { JOBS_QUERY_KEY }

--- a/frontend/src/hooks/useUpdateJobStatus.ts
+++ b/frontend/src/hooks/useUpdateJobStatus.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { patch } from '../api/client'
+import type { Job, PaginatedResponse } from '../types'
+import { JOBS_QUERY_KEY } from './useJobs'
+
+interface UpdateJobStatusInput {
+  jobId: number
+  job_status_id: number
+}
+
+interface JobsQueryContext {
+  previousJobs?: PaginatedResponse<Job>
+}
+
+export const useUpdateJobStatus = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation<Job, Error, UpdateJobStatusInput, JobsQueryContext>({
+    mutationFn: ({ jobId, job_status_id }) =>
+      patch<Job, Partial<Job>>(`/jobs/${jobId}`, { job_status_id }),
+    onMutate: async ({ jobId, job_status_id }) => {
+      await queryClient.cancelQueries({ queryKey: JOBS_QUERY_KEY })
+
+      const previousJobs = queryClient.getQueryData<PaginatedResponse<Job>>(JOBS_QUERY_KEY)
+
+      if (previousJobs) {
+        const nextJobs: PaginatedResponse<Job> = {
+          ...previousJobs,
+          data: previousJobs.data.map((job) =>
+            job.id === jobId ? { ...job, job_status_id } : job,
+          ),
+        }
+
+        queryClient.setQueryData(JOBS_QUERY_KEY, nextJobs)
+      }
+
+      return { previousJobs }
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousJobs) {
+        queryClient.setQueryData(JOBS_QUERY_KEY, context.previousJobs)
+      }
+    },
+    onSuccess: (updatedJob) => {
+      queryClient.setQueryData<PaginatedResponse<Job> | undefined>(
+        JOBS_QUERY_KEY,
+        (current) => {
+          if (!current) {
+            return current
+          }
+
+          return {
+            ...current,
+            data: current.data.map((job) => (job.id === updatedJob.id ? updatedJob : job)),
+          }
+        },
+      )
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: JOBS_QUERY_KEY })
+    },
+  })
+}
+
+export type UseUpdateJobStatusResult = ReturnType<typeof useUpdateJobStatus>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,43 @@
+export interface JobStatus {
+  id: number
+  name: string
+  slug: string
+  sort_order: number
+  is_default: boolean
+}
+
+export interface JobNote {
+  id: number
+  body: string
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface Job {
+  id: number
+  title: string
+  company: string
+  location: string | null
+  salary: string | null
+  applied_at: string | null
+  posting_url: string | null
+  job_status_id: number
+  status?: JobStatus | null
+  notes?: JobNote[]
+  created_at: string | null
+  updated_at: string | null
+}
+
+export interface PaginatedResponse<T> {
+  data: T[]
+  links?: Record<string, string | null>
+  meta?: {
+    current_page: number
+    from: number | null
+    last_page: number
+    path?: string
+    per_page: number
+    to: number | null
+    total: number
+  }
+}


### PR DESCRIPTION
## Summary
- add React Query hooks for fetching jobs and job statuses and for updating job status via the Axios client
- replace the placeholder workspace with a Kanban board composed of column and card components wired to drag-and-drop events
- extend styling to support the interactive board along with loading, error, and empty states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de2df3e5d48325a4594c2a9d67aa70