### PR TITLE
Adjust job statuses hook response handling

### DIFF
--- a/frontend/src/hooks/useJobStatuses.ts
+++ b/frontend/src/hooks/useJobStatuses.ts
@@ -7,8 +7,8 @@ const JOB_STATUSES_QUERY_KEY = ['job-statuses'] as const
 export const useJobStatuses = () =>
   useQuery({
     queryKey: JOB_STATUSES_QUERY_KEY,
-    queryFn: () => get<JobStatus[]>('/job-statuses'),
-    select: (statuses) => [...statuses].sort((a, b) => a.sort_order - b.sort_order),
+    queryFn: () => get<{ data: JobStatus[] }>('/job-statuses'),
+    select: ({ data }) => [...data].sort((a, b) => a.sort_order - b.sort_order),
     staleTime: 5 * 60 * 1000,
   })
 


### PR DESCRIPTION
## Summary
- update the job statuses query to expect the API response object with a data array
- keep the existing sort while applying it to the extracted job status array

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de33024940832598eb6c23375d40ce