### PR TITLE
Handle job status mutation response envelope

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,7 @@
+export interface ApiResource<T> {
+  data: T
+}
+
 export interface JobStatus {
   id: number
   name: string


### PR DESCRIPTION
## Summary
- add a reusable `ApiResource<T>` interface for Laravel resource payloads
- update the job status mutation to expect the resource envelope and merge the returned job into the cache

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de365338608325a7bf4b064b5dd10b