### PR TITLE
Remove action center from dashboard layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,220 +1,418 @@
 @import "tailwindcss";
 
 :root {
+  color-scheme: light;
   --color-background: #f8fafc;
   --color-surface: #ffffff;
-  --color-sidebar-bg: #0f172a;
-  --color-sidebar-muted: #1e293b;
-  --color-sidebar-text: #e2e8f0;
-  --color-sidebar-active: #38bdf8;
+  --color-surface-muted: #f1f5f9;
+  --color-surface-strong: #0f172a;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-border-strong: rgba(148, 163, 184, 0.25);
   --color-text: #0f172a;
   --color-text-muted: #475569;
-  --color-border: rgba(15, 23, 42, 0.08);
-  --color-primary: #2563eb;
-  --color-primary-contrast: #f8fafc;
-  --color-placeholder-bg: rgba(148, 163, 184, 0.12);
-}
-
-:root[data-theme='dark'] {
-  --color-background: #0f172a;
-  --color-surface: #111827;
-  --color-sidebar-bg: #020617;
-  --color-sidebar-muted: #111827;
-  --color-sidebar-text: #cbd5f5;
-  --color-sidebar-active: #60a5fa;
-  --color-text: #e2e8f0;
-  --color-text-muted: #94a3b8;
-  --color-border: rgba(148, 163, 184, 0.32);
-  --color-primary: #60a5fa;
-  --color-primary-contrast: #020617;
-  --color-placeholder-bg: rgba(15, 23, 42, 0.35);
+  --color-text-on-dark: rgba(248, 250, 252, 0.88);
+  --color-brand: #6366f1;
+  --color-brand-strong: #4f46e5;
+  --color-brand-soft: rgba(99, 102, 241, 0.16);
+  --color-accent: #22d3ee;
+  --shadow-lg: 0 30px 60px rgba(15, 23, 42, 0.18);
+  --shadow-card: 0 18px 45px rgba(15, 23, 42, 0.12);
+  --radius-lg: 1.5rem;
+  --radius-md: 1rem;
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
 }
 
 #root {
   min-height: 100vh;
-}
-
-.app {
-  display: grid;
-  grid-template-columns: 18rem 1fr;
-  min-height: 100vh;
-  background: var(--color-background);
+  background: radial-gradient(circle at top, rgba(99, 102, 241, 0.08), transparent 55%),
+    radial-gradient(circle at 35% 10%, rgba(34, 211, 238, 0.08), transparent 45%), var(--color-background);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
   color: var(--color-text);
 }
 
-.sidebar {
-  background: linear-gradient(180deg, var(--color-sidebar-bg) 0%, var(--color-sidebar-muted) 100%);
-  color: var(--color-sidebar-text);
-  display: flex;
-  flex-direction: column;
-  gap: 2.5rem;
-  padding: 2.5rem 2rem;
-  border-right: 1px solid rgba(148, 163, 184, 0.2);
-}
-
-.sidebar__brand {
-  display: flex;
-  gap: 1rem;
-  align-items: center;
-}
-
-.sidebar__brand h1 {
-  font-size: 1.25rem;
-  margin: 0 0 0.25rem;
-}
-
-.sidebar__brand p {
-  margin: 0;
-  font-size: 0.875rem;
-  color: var(--color-sidebar-text);
-  opacity: 0.85;
-}
-
-.sidebar__brand-badge {
+.app-shell {
   display: grid;
-  place-items: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 0.75rem;
-  background: rgba(59, 130, 246, 0.25);
-  color: var(--color-sidebar-active);
-  font-weight: 700;
-  font-size: 1.125rem;
-  letter-spacing: 0.04em;
+  gap: clamp(1.75rem, 4vw, 2.5rem);
 }
 
-.sidebar__nav {
+.hero-header {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, #0b1120, #1e1b4b 55%, #312e81);
+  color: var(--color-text-on-dark);
+  padding: clamp(2.25rem, 5vw, 3rem);
+  box-shadow: var(--shadow-lg);
+}
+
+.hero-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 85% 15%, rgba(34, 211, 238, 0.2), transparent 45%),
+    radial-gradient(circle at 10% 100%, rgba(129, 140, 248, 0.35), transparent 55%);
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.hero-header__content {
+  position: relative;
   display: grid;
-  gap: 0.5rem;
+  gap: 1.5rem;
+  max-width: 38rem;
+  z-index: 1;
 }
 
-.sidebar__link {
+.hero-header__eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.625rem 0.75rem;
-  border-radius: 0.75rem;
-  color: inherit;
-  text-decoration: none;
-  font-weight: 500;
-  transition: background 160ms ease, color 160ms ease;
-}
-
-.sidebar__link:hover,
-.sidebar__link:focus-visible {
-  background: rgba(148, 163, 184, 0.15);
-  outline: none;
-}
-
-.sidebar__link--active {
-  background: rgba(56, 189, 248, 0.2);
-  color: var(--color-sidebar-active);
-}
-
-.sidebar__footer {
-  margin-top: auto;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.sidebar__new-board {
-  background: rgba(59, 130, 246, 0.85);
-  color: var(--color-primary-contrast);
-  border: none;
-  border-radius: 0.75rem;
-  padding: 0.75rem 1rem;
-  font-size: 0.95rem;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(248, 250, 252, 0.12);
+  font-size: 0.85rem;
   font-weight: 600;
-  cursor: pointer;
-  transition: filter 160ms ease;
+  letter-spacing: 0.02em;
 }
 
-.sidebar__new-board:hover,
-.sidebar__new-board:focus-visible {
-  filter: brightness(1.1);
-  outline: none;
+.hero-header__eyebrow svg {
+  width: 1.1rem;
 }
 
-.sidebar__hint {
-  margin: 0;
-  font-size: 0.75rem;
-  line-height: 1.4;
-  opacity: 0.7;
-}
-
-.workspace {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  padding: 2.5rem 3rem;
-  background: var(--color-background);
-  min-height: 0;
-}
-
-.workspace__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 2rem;
-}
-
-.workspace__header h2 {
-  margin: 0 0 0.5rem;
-  font-size: 2rem;
+.hero-header__headline h1 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(2.1rem, 4vw, 2.85rem);
   font-weight: 700;
 }
 
-.workspace__header p {
+.hero-header__headline p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: rgba(241, 245, 249, 0.88);
+}
+
+.hero-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero-header__cta {
+  border-radius: 999px;
+  border: 1px solid rgba(248, 250, 252, 0.28);
+  background: rgba(15, 23, 42, 0.45);
+  color: var(--color-text-on-dark);
+  font-weight: 600;
+  padding: 0.7rem 1.5rem;
+  cursor: pointer;
+  transition: transform 150ms ease, background 150ms ease, border-color 150ms ease;
+}
+
+.hero-header__cta:hover,
+.hero-header__cta:focus-visible {
+  transform: translateY(-1px);
+  background: rgba(15, 23, 42, 0.65);
+  border-color: rgba(248, 250, 252, 0.4);
+  outline: none;
+}
+
+.hero-header__cta--primary {
+  background: linear-gradient(120deg, var(--color-brand), var(--color-accent));
+  border-color: transparent;
+  color: white;
+  box-shadow: 0 18px 38px rgba(79, 70, 229, 0.4);
+}
+
+.hero-header__stats {
+  position: absolute;
+  inset: auto 2.5rem -2.5rem auto;
+  display: grid;
+  gap: 1rem;
+  min-width: 18rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-md);
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow-card);
+}
+
+.hero-header__stat-card {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hero-header__stat-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.76);
+}
+
+.hero-header__stat-value {
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.hero-header__stat-trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.hero-header__stat-trend--positive {
+  color: #a5f3fc;
+}
+
+.hero-header__stat-trend--positive svg {
+  width: 1rem;
+}
+
+.dashboard-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  grid-template-columns: minmax(0, 1.75fr) minmax(16rem, 22rem);
+  align-items: start;
+}
+
+.dashboard-grid__column {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.dashboard-grid__column--center {
+  min-width: 0;
+}
+
+.applications-board {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: var(--shadow-card);
+  border: 1px solid var(--color-border);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 0;
+}
+
+.applications-board__header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.applications-board__eyebrow {
+  margin: 0 0 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-brand);
+}
+
+.applications-board__header h2 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.5rem, 2.5vw, 1.8rem);
+}
+
+.applications-board__description {
+  margin: 0;
+  max-width: 38ch;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.applications-board__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
+.applications-board__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-weight: 600;
+  padding: 0.65rem 1.2rem;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease, transform 150ms ease;
+}
+
+.applications-board__button svg {
+  width: 1.1rem;
+}
+
+.applications-board__button:hover,
+.applications-board__button:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: var(--color-border-strong);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.applications-board__button--primary {
+  background: var(--color-brand);
+  border-color: var(--color-brand);
+  color: white;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.35);
+}
+
+.applications-board__body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.upcoming-interviews {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.upcoming-interviews__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.upcoming-interviews__eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-brand);
+}
+
+.upcoming-interviews__header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.upcoming-interviews__view-calendar {
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-weight: 600;
+  padding: 0.55rem 1.1rem;
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.upcoming-interviews__view-calendar:hover,
+.upcoming-interviews__view-calendar:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: var(--color-border-strong);
+  outline: none;
+}
+
+.upcoming-interviews__calendar {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.75rem;
+  background: var(--color-surface-muted);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.upcoming-interviews__calendar-day {
+  display: grid;
+  gap: 0.3rem;
+  text-align: center;
+  padding: 0.75rem 0.5rem;
+  border-radius: 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.upcoming-interviews__calendar-day strong {
+  font-size: 1.1rem;
+  color: var(--color-text);
+}
+
+.upcoming-interviews__calendar-day--active {
+  background: var(--color-brand);
+  color: white;
+}
+
+.upcoming-interviews__calendar-day--active strong {
+  color: inherit;
+}
+
+.upcoming-interviews__calendar-day--highlighted {
+  border: 2px solid var(--color-brand-soft);
+}
+
+.upcoming-interviews__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.upcoming-interviews__item {
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  padding: 1rem 1.15rem;
+  display: grid;
+  gap: 0.75rem;
+  background: var(--color-surface);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.upcoming-interviews__item:hover,
+.upcoming-interviews__item:focus-within {
+  border-color: var(--color-brand);
+  box-shadow: 0 16px 32px rgba(99, 102, 241, 0.18);
+}
+
+.upcoming-interviews__item-company {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.upcoming-interviews__item-role {
   margin: 0;
   font-size: 0.95rem;
   color: var(--color-text-muted);
 }
 
-.workspace__actions {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.workspace__action {
-  border-radius: 999px;
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-text);
-  font-weight: 600;
-  padding: 0.65rem 1.2rem;
-  cursor: pointer;
-  transition: background 160ms ease, border-color 160ms ease, color 160ms ease;
-}
-
-.workspace__action:hover,
-.workspace__action:focus-visible {
-  background: rgba(148, 163, 184, 0.12);
-  outline: none;
-}
-
-.workspace__action--primary {
-  background: var(--color-primary);
-  border-color: var(--color-primary);
-  color: var(--color-primary-contrast);
-}
-
-.workspace__action--primary:hover,
-.workspace__action--primary:focus-visible {
-  background: #1d4ed8;
-}
-
-.kanban {
-  flex: 1;
-  background: var(--color-surface);
-  border-radius: 1.5rem;
-  border: 1px solid var(--color-border);
-  padding: 1.5rem;
+.upcoming-interviews__item-meta {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
-  min-height: 0;
-  overflow: hidden;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+}
+
+.upcoming-interviews__item-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.upcoming-interviews__item-meta svg {
+  width: 1rem;
+  color: var(--color-brand-strong);
 }
 
 .kanban__placeholder {
@@ -225,7 +423,7 @@
   border-radius: 1rem;
   padding: 2rem;
   color: var(--color-text-muted);
-  background: var(--color-placeholder-bg);
+  background: rgba(148, 163, 184, 0.12);
   text-align: center;
   font-size: 0.95rem;
   line-height: 1.5;
@@ -236,13 +434,13 @@
   display: flex;
   flex-direction: column;
   min-height: 0;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
 .kanban__columns {
   flex: 1;
   display: flex;
-  gap: 1.5rem;
+  gap: 1.35rem;
   align-items: flex-start;
   overflow-x: auto;
   padding-bottom: 0.5rem;
@@ -253,12 +451,12 @@
 }
 
 .kanban__columns::-webkit-scrollbar-thumb {
-  background-color: rgba(148, 163, 184, 0.4);
+  background-color: rgba(148, 163, 184, 0.3);
   border-radius: 999px;
 }
 
 .kanban__column {
-  background: var(--color-background);
+  background: var(--color-surface-muted);
   border-radius: 1.25rem;
   border: 1px solid var(--color-border);
   padding: 1.25rem;
@@ -266,12 +464,13 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  transition: border-color 160ms ease, box-shadow 160ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
 .kanban__column--over {
-  border-color: var(--color-primary);
-  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.15);
+  border-color: var(--color-brand);
+  box-shadow: 0 20px 40px rgba(99, 102, 241, 0.2);
+  transform: translateY(-2px);
 }
 
 .kanban__column-header {
@@ -294,8 +493,8 @@
   min-width: 2rem;
   height: 1.75rem;
   border-radius: 999px;
-  background: rgba(37, 99, 235, 0.1);
-  color: var(--color-primary);
+  background: var(--color-brand-soft);
+  color: var(--color-brand-strong);
   font-size: 0.85rem;
   font-weight: 600;
 }
@@ -329,7 +528,7 @@
   border-radius: 1rem;
   border: 1px solid var(--color-border);
   padding: 1rem;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
   display: grid;
   gap: 0.75rem;
   cursor: grab;
@@ -341,9 +540,10 @@
 }
 
 .kanban__card--dragging {
-  opacity: 0.7;
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.25);
-  border-color: var(--color-primary);
+  opacity: 0.75;
+  box-shadow: 0 22px 48px rgba(99, 102, 241, 0.3);
+  border-color: var(--color-brand);
+  transform: rotate(-0.5deg) scale(1.01);
 }
 
 .kanban__card-header {
@@ -372,49 +572,44 @@
 }
 
 .kanban__card-meta span::before {
-  content: '•';
+  content: "•";
   margin-right: 0.35rem;
 }
 
 .kanban__card-meta span:first-of-type::before {
-  content: '';
+  content: "";
   margin-right: 0;
 }
 
-@media (max-width: 1024px) {
-  .app {
-    grid-template-columns: 16rem 1fr;
-  }
-  .workspace {
-    padding: 2rem;
+@media (max-width: 1200px) {
+  .dashboard-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
-@media (max-width: 768px) {
-  .app {
-    grid-template-columns: 1fr;
+@media (max-width: 900px) {
+  .hero-header__stats {
+    position: static;
+    inset: auto;
+    margin-top: 2rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .sidebar {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    border-right: none;
-    border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  .hero-header {
+    padding-bottom: 3.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  #root {
+    padding: 1.25rem;
   }
 
-  .workspace {
-    padding: 1.5rem;
+  .hero-header {
+    padding: 2rem;
   }
 
-  .workspace__header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .workspace__actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
+  .hero-header__stats {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,54 +1,22 @@
 import './App.css'
-import { KanbanBoard } from './components/KanbanBoard'
+import { HeroHeader } from './components/dashboard/HeroHeader'
+import { ApplicationsBoard } from './components/dashboard/ApplicationsBoard'
+import { UpcomingInterviews } from './components/dashboard/UpcomingInterviews'
 
 export default function App() {
   return (
-    <div className="app">
-      <aside className="sidebar">
-        <div className="sidebar__brand">
-          <span className="sidebar__brand-badge">JT</span>
-          <div>
-            <h1>Job Tracker</h1>
-            <p>Stay on top of every opportunity.</p>
-          </div>
+    <div className="app-shell">
+      <HeroHeader />
+
+      <main className="dashboard-grid">
+        <div className="dashboard-grid__column dashboard-grid__column--center">
+          <ApplicationsBoard />
         </div>
 
-        <nav className="sidebar__nav" aria-label="Primary navigation">
-          <a className="sidebar__link sidebar__link--active" href="#">Kanban board</a>
-          <a className="sidebar__link" href="#">Calendar</a>
-          <a className="sidebar__link" href="#">Reports</a>
-          <a className="sidebar__link" href="#">Settings</a>
-        </nav>
-
-        <div className="sidebar__footer">
-          <button className="sidebar__new-board" type="button">
-            + New board
-          </button>
-          <p className="sidebar__hint">Organize positions by team or workflow.</p>
+        <div className="dashboard-grid__column dashboard-grid__column--right">
+          <UpcomingInterviews />
         </div>
-      </aside>
-
-      <div className="workspace">
-        <header className="workspace__header">
-          <div>
-            <h2>Applications pipeline</h2>
-            <p>Monitor each application as it moves from prospect to offer.</p>
-          </div>
-
-          <div className="workspace__actions">
-            <button className="workspace__action workspace__action--primary" type="button">
-              Add application
-            </button>
-            <button className="workspace__action" type="button">
-              Filter
-            </button>
-          </div>
-        </header>
-
-        <section className="kanban" aria-label="Kanban board">
-          <KanbanBoard />
-        </section>
-      </div>
+      </main>
     </div>
   )
 }

--- a/frontend/src/components/dashboard/ApplicationsBoard.tsx
+++ b/frontend/src/components/dashboard/ApplicationsBoard.tsx
@@ -1,0 +1,34 @@
+import { FunnelIcon, PlusIcon } from './icons'
+import { KanbanBoard } from '../../components/KanbanBoard'
+
+export const ApplicationsBoard = () => {
+  return (
+    <section className="applications-board" aria-labelledby="applications-board-heading">
+      <header className="applications-board__header">
+        <div>
+          <p className="applications-board__eyebrow">Pipeline overview</p>
+          <h2 id="applications-board-heading">Applications board</h2>
+          <p className="applications-board__description">
+            Drag cards between stages to keep each opportunity up to date. Everything stays in sync across
+            your team.
+          </p>
+        </div>
+
+        <div className="applications-board__actions">
+          <button type="button" className="applications-board__button applications-board__button--primary">
+            <PlusIcon aria-hidden="true" />
+            New application
+          </button>
+          <button type="button" className="applications-board__button">
+            <FunnelIcon aria-hidden="true" />
+            Filter
+          </button>
+        </div>
+      </header>
+
+      <div className="applications-board__body">
+        <KanbanBoard />
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/HeroHeader.tsx
+++ b/frontend/src/components/dashboard/HeroHeader.tsx
@@ -1,0 +1,48 @@
+import { CalendarDaysIcon, SparklesIcon } from './icons'
+
+export const HeroHeader = () => {
+  return (
+    <header className="hero-header" aria-labelledby="hero-heading">
+      <div className="hero-header__content">
+        <div className="hero-header__eyebrow">
+          <SparklesIcon aria-hidden="true" />
+          <span>Career workspace</span>
+        </div>
+
+        <div className="hero-header__headline">
+          <h1 id="hero-heading">Good morning, Alex</h1>
+          <p>
+            Track applications, collaborate with referrals, and keep interviews organized in a single
+            streamlined workspace.
+          </p>
+        </div>
+
+        <div className="hero-header__actions">
+          <button className="hero-header__cta hero-header__cta--primary" type="button">
+            Add application
+          </button>
+          <button className="hero-header__cta" type="button">
+            Share pipeline
+          </button>
+        </div>
+      </div>
+
+      <div className="hero-header__stats" aria-label="Pipeline summary">
+        <div className="hero-header__stat-card">
+          <span className="hero-header__stat-label">Active applications</span>
+          <strong className="hero-header__stat-value">18</strong>
+          <span className="hero-header__stat-trend">+3 since last week</span>
+        </div>
+
+        <div className="hero-header__stat-card">
+          <span className="hero-header__stat-label">Interviews scheduled</span>
+          <strong className="hero-header__stat-value">4</strong>
+          <span className="hero-header__stat-trend hero-header__stat-trend--positive">
+            <CalendarDaysIcon aria-hidden="true" />
+            Next on Jul 11
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/dashboard/UpcomingInterviews.tsx
+++ b/frontend/src/components/dashboard/UpcomingInterviews.tsx
@@ -1,0 +1,98 @@
+import { ClockIcon, MapPinIcon, VideoCameraIcon } from './icons'
+
+const interviews = [
+  {
+    id: 1,
+    company: 'Aurora Systems',
+    role: 'Senior Product Designer',
+    date: 'Tue, Jul 9',
+    time: '9:30 AM',
+    type: 'Virtual',
+    location: 'Zoom',
+  },
+  {
+    id: 2,
+    company: 'Luma Labs',
+    role: 'Product Strategist',
+    date: 'Thu, Jul 11',
+    time: '1:00 PM',
+    type: 'Onsite',
+    location: 'San Francisco HQ',
+  },
+  {
+    id: 3,
+    company: 'Northwind Tech',
+    role: 'Design Manager',
+    date: 'Mon, Jul 15',
+    time: '11:00 AM',
+    type: 'Virtual',
+    location: 'Google Meet',
+  },
+]
+
+const calendarDays = [
+  { label: 'Mon', date: 8 },
+  { label: 'Tue', date: 9, isActive: true },
+  { label: 'Wed', date: 10 },
+  { label: 'Thu', date: 11, isHighlighted: true },
+  { label: 'Fri', date: 12 },
+  { label: 'Sat', date: 13 },
+  { label: 'Sun', date: 14 },
+]
+
+export const UpcomingInterviews = () => {
+  return (
+    <section className="upcoming-interviews" aria-labelledby="upcoming-interviews-heading">
+      <header className="upcoming-interviews__header">
+        <div>
+          <p className="upcoming-interviews__eyebrow">Calendar</p>
+          <h2 id="upcoming-interviews-heading">Upcoming interviews</h2>
+        </div>
+
+        <button type="button" className="upcoming-interviews__view-calendar">
+          View full calendar
+        </button>
+      </header>
+
+      <div className="upcoming-interviews__calendar" aria-label="This week">
+        {calendarDays.map((day) => (
+          <div
+            key={day.date}
+            className={[
+              'upcoming-interviews__calendar-day',
+              day.isActive ? 'upcoming-interviews__calendar-day--active' : '',
+              day.isHighlighted ? 'upcoming-interviews__calendar-day--highlighted' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
+            <span>{day.label}</span>
+            <strong>{day.date}</strong>
+          </div>
+        ))}
+      </div>
+
+      <ul className="upcoming-interviews__list">
+        {interviews.map((interview) => (
+          <li key={interview.id} className="upcoming-interviews__item">
+            <div className="upcoming-interviews__item-header">
+              <p className="upcoming-interviews__item-company">{interview.company}</p>
+              <p className="upcoming-interviews__item-role">{interview.role}</p>
+            </div>
+
+            <div className="upcoming-interviews__item-meta">
+              <span>
+                <ClockIcon aria-hidden="true" />
+                {interview.date} · {interview.time}
+              </span>
+              <span>
+                {interview.type === 'Virtual' ? <VideoCameraIcon aria-hidden="true" /> : <MapPinIcon aria-hidden="true" />}
+                {interview.type === 'Virtual' ? interview.location : `${interview.type} · ${interview.location}`}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/frontend/src/components/dashboard/icons.tsx
+++ b/frontend/src/components/dashboard/icons.tsx
@@ -1,0 +1,60 @@
+import type { SVGProps } from 'react'
+
+const baseIconProps = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.6,
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+} as const satisfies SVGProps<SVGSVGElement>
+
+type IconProps = Omit<SVGProps<SVGSVGElement>, 'xmlns'>
+
+export const SparklesIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <path d="M11.5 3.2 13 7.7h4.5l-3.7 2.7 1.5 4.5-3.8-2.8-3.8 2.8 1.5-4.5L5.5 7.7H10L11.5 3.2z" />
+    <path d="M5.25 4.75 5.9 6.5h1.75l-1.45 1.05.55 1.75-1.5-1.1-1.5 1.1.55-1.75L3 6.5h1.75l.5-1.75z" />
+    <path d="m18.75 5.25.65 1.75h1.75l-1.45 1.05.55 1.75-1.5-1.1-1.5 1.1.55-1.75L16.5 7h1.75l.5-1.75z" />
+  </svg>
+)
+
+export const CalendarDaysIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <rect x="3.5" y="4.5" width="17" height="15" rx="2.5" />
+    <path d="M7 3.5V6m10-2.5V6M3.5 9.5h17M8.5 13h3m-3 4h3m4-4h3" />
+  </svg>
+)
+
+export const PlusIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <path d="M12 5v14M5 12h14" />
+  </svg>
+)
+
+export const FunnelIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <path d="M4.5 6h15L14 12.25v5.5l-4 1.75v-7.25L4.5 6z" />
+  </svg>
+)
+
+export const ClockIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <circle cx="12" cy="12" r="8.5" />
+    <path d="M12 7.5V12l2.75 2.75" />
+  </svg>
+)
+
+export const MapPinIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <path d="M12 20.25s6-4.5 6-9.25a6 6 0 0 0-12 0c0 4.75 6 9.25 6 9.25z" />
+    <circle cx="12" cy="11" r="2.25" />
+  </svg>
+)
+
+export const VideoCameraIcon = (props: IconProps) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" {...baseIconProps} {...props}>
+    <rect x="3.5" y="6.5" width="11.5" height="11" rx="2.25" />
+    <path d="m14.5 10 4-2.5v8.5l-4-2.5" />
+  </svg>
+)


### PR DESCRIPTION
## Summary
- remove the quick actions/action center component from the dashboard composition so only the applications board and upcoming interviews remain
- simplify dashboard styling for the two-column layout and drop quick action styles and unused icons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de413d27e08325af3c9bf4d52a0ed7