### PR TITLE
Use API-driven data for upcoming interviews

### DIFF
--- a/backend/app/Http/Controllers/InterviewController.php
+++ b/backend/app/Http/Controllers/InterviewController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\InterviewResource;
+use App\Models\Interview;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+class InterviewController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $interviews = Interview::query()
+            ->where('scheduled_at', '>=', now()->startOfDay())
+            ->orderBy('scheduled_at')
+            ->get();
+
+        return InterviewResource::collection($interviews);
+    }
+}

--- a/backend/app/Http/Resources/InterviewResource.php
+++ b/backend/app/Http/Resources/InterviewResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin \App\Models\Interview */
+class InterviewResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'company' => $this->company,
+            'role' => $this->role,
+            'scheduled_at' => $this->scheduled_at?->toISOString(),
+            'format' => $this->format,
+            'location' => $this->location,
+        ];
+    }
+}

--- a/backend/app/Models/Interview.php
+++ b/backend/app/Models/Interview.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+class Interview extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'company',
+        'role',
+        'scheduled_at',
+        'format',
+        'location',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+    ];
+}

--- a/backend/database/migrations/2025_10_01_160000_create_interviews_table.php
+++ b/backend/database/migrations/2025_10_01_160000_create_interviews_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('interviews', function (Blueprint $table): void {
+            $table->id();
+            $table->string('company');
+            $table->string('role');
+            $table->dateTime('scheduled_at');
+            $table->enum('format', ['virtual', 'in_person'])->default('virtual');
+            $table->string('location');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('interviews');
+    }
+};

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -10,8 +10,10 @@ class DatabaseSeeder extends Seeder
      * Seed the application's database.
      */
     public function run(): void
-{
-    
-    $this->call(JobStatusSeeder::class);    
+    {
+        $this->call([
+            JobStatusSeeder::class,
+            InterviewSeeder::class,
+        ]);
     }
 }

--- a/backend/database/seeders/InterviewSeeder.php
+++ b/backend/database/seeders/InterviewSeeder.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class InterviewSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $now = Carbon::now();
+        $startOfWeek = (clone $now)->startOfWeek(Carbon::MONDAY);
+
+        DB::table('interviews')->delete();
+
+        DB::table('interviews')->insert([
+            [
+                'company' => 'Aurora Systems',
+                'role' => 'Senior Product Designer',
+                'scheduled_at' => (clone $startOfWeek)->addDays(1)->setTime(9, 30),
+                'format' => 'virtual',
+                'location' => 'Zoom',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'company' => 'Luma Labs',
+                'role' => 'Product Strategist',
+                'scheduled_at' => (clone $startOfWeek)->addDays(3)->setTime(13, 0),
+                'format' => 'in_person',
+                'location' => 'San Francisco HQ',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'company' => 'Northwind Tech',
+                'role' => 'Design Manager',
+                'scheduled_at' => (clone $startOfWeek)->addDays(7)->setTime(11, 0),
+                'format' => 'virtual',
+                'location' => 'Google Meet',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\InterviewController;
 use App\Http\Controllers\JobController;
 use App\Http\Controllers\JobNoteController;
 use App\Http\Controllers\JobStatusController;
@@ -7,6 +8,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware(['throttle:api'])->group(static function (): void {
     Route::get('job-statuses', [JobStatusController::class, 'index'])->name('job-statuses.index');
+    Route::get('interviews/upcoming', [InterviewController::class, 'index'])->name('interviews.upcoming');
 
     Route::apiResource('jobs', JobController::class);
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -415,6 +415,13 @@
   color: var(--color-brand-strong);
 }
 
+.upcoming-interviews__placeholder {
+  margin: 0;
+  padding: 1rem 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
 .kanban__placeholder {
   flex: 1;
   display: grid;

--- a/frontend/src/components/dashboard/UpcomingInterviews.tsx
+++ b/frontend/src/components/dashboard/UpcomingInterviews.tsx
@@ -1,51 +1,136 @@
+import { useMemo } from 'react'
+import { useUpcomingInterviews } from '../../hooks/useUpcomingInterviews'
+import type { UpcomingInterview as UpcomingInterviewType } from '../../types'
 import { ClockIcon, MapPinIcon, VideoCameraIcon } from './icons'
 
-const interviews = [
-  {
-    id: 1,
-    company: 'Aurora Systems',
-    role: 'Senior Product Designer',
-    date: 'Tue, Jul 9',
-    time: '9:30 AM',
-    type: 'Virtual',
-    location: 'Zoom',
-  },
-  {
-    id: 2,
-    company: 'Luma Labs',
-    role: 'Product Strategist',
-    date: 'Thu, Jul 11',
-    time: '1:00 PM',
-    type: 'Onsite',
-    location: 'San Francisco HQ',
-  },
-  {
-    id: 3,
-    company: 'Northwind Tech',
-    role: 'Design Manager',
-    date: 'Mon, Jul 15',
-    time: '11:00 AM',
-    type: 'Virtual',
-    location: 'Google Meet',
-  },
-]
+type CalendarDay = {
+  label: string
+  date: number
+  dateObj: Date
+  key: string
+  isActive: boolean
+  isHighlighted: boolean
+}
 
-const calendarDays = [
-  { label: 'Mon', date: 8 },
-  { label: 'Tue', date: 9, isActive: true },
-  { label: 'Wed', date: 10 },
-  { label: 'Thu', date: 11, isHighlighted: true },
-  { label: 'Fri', date: 12 },
-  { label: 'Sat', date: 13 },
-  { label: 'Sun', date: 14 },
-]
+const getStartOfWeek = (date: Date) => {
+  const day = date.getDay()
+  const distanceFromMonday = (day + 6) % 7
+  const start = new Date(date)
+  start.setHours(0, 0, 0, 0)
+  start.setDate(date.getDate() - distanceFromMonday)
+  return start
+}
+
+const buildCalendarDays = (today: Date, highlightDate?: Date | null): CalendarDay[] => {
+  const startOfWeek = getStartOfWeek(today)
+
+  return Array.from({ length: 7 }, (_, index) => {
+    const day = new Date(startOfWeek)
+    day.setDate(startOfWeek.getDate() + index)
+
+    const isSameDay = (first: Date, second?: Date | null) =>
+      !!second && first.toDateString() === second.toDateString()
+
+    return {
+      label: day.toLocaleDateString(undefined, { weekday: 'short' }),
+      date: day.getDate(),
+      dateObj: day,
+      key: day.toISOString(),
+      isActive: isSameDay(day, today),
+      isHighlighted: isSameDay(day, highlightDate ?? null),
+    }
+  })
+}
+
+const formatInterviewDate = (date: Date) =>
+  date.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+
+const formatInterviewTime = (date: Date) =>
+  date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+
+const getFormatLabel = (format: UpcomingInterviewType['format']) =>
+  (format === 'virtual' ? 'Virtual' : 'Onsite')
+
+const isVirtualInterview = (format: UpcomingInterviewType['format']) => format === 'virtual'
 
 export const UpcomingInterviews = () => {
+  const upcomingInterviewsQuery = useUpcomingInterviews()
+
+  const interviews = useMemo(() => {
+    const rawInterviews = upcomingInterviewsQuery.data ?? []
+
+    return rawInterviews
+      .map((interview) => ({
+        ...interview,
+        scheduledAt: new Date(interview.scheduled_at),
+      }))
+      .sort((first, second) => first.scheduledAt.getTime() - second.scheduledAt.getTime())
+  }, [upcomingInterviewsQuery.data])
+
+  const nextInterviewDate = interviews[0]?.scheduledAt ?? null
+  const calendarDays = useMemo(() => {
+    const now = new Date()
+    return buildCalendarDays(now, nextInterviewDate)
+  }, [nextInterviewDate])
+
+  const listContent = () => {
+    if (upcomingInterviewsQuery.isLoading) {
+      return <p className="upcoming-interviews__placeholder">Loading upcoming interviews…</p>
+    }
+
+    if (upcomingInterviewsQuery.isError) {
+      return (
+        <p className="upcoming-interviews__placeholder" role="alert">
+          We couldn’t load your interviews right now. Please try again soon.
+        </p>
+      )
+    }
+
+    if (interviews.length === 0) {
+      return <p className="upcoming-interviews__placeholder">No interviews scheduled yet.</p>
+    }
+
+    return (
+      <ul className="upcoming-interviews__list">
+        {interviews.map((interview) => {
+          const typeLabel = getFormatLabel(interview.format)
+          const isVirtual = isVirtualInterview(interview.format)
+
+          return (
+            <li key={interview.id} className="upcoming-interviews__item">
+              <div className="upcoming-interviews__item-header">
+                <p className="upcoming-interviews__item-company">{interview.company}</p>
+                <p className="upcoming-interviews__item-role">{interview.role}</p>
+              </div>
+
+              <div className="upcoming-interviews__item-meta">
+                <span>
+                  <ClockIcon aria-hidden="true" />
+                  {formatInterviewDate(interview.scheduledAt)} · {formatInterviewTime(interview.scheduledAt)}
+                </span>
+                <span>
+                  {isVirtual ? <VideoCameraIcon aria-hidden="true" /> : <MapPinIcon aria-hidden="true" />}
+                  {isVirtual ? interview.location : `${typeLabel} · ${interview.location}`}
+                </span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    )
+  }
+
+  const calendarLabel = calendarDays.length
+    ? `Week of ${calendarDays[0].dateObj.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+      })}`
+    : 'This week'
+
   return (
     <section className="upcoming-interviews" aria-labelledby="upcoming-interviews-heading">
       <header className="upcoming-interviews__header">
         <div>
-          <p className="upcoming-interviews__eyebrow">Calendar</p>
           <h2 id="upcoming-interviews-heading">Upcoming interviews</h2>
         </div>
 
@@ -54,10 +139,10 @@ export const UpcomingInterviews = () => {
         </button>
       </header>
 
-      <div className="upcoming-interviews__calendar" aria-label="This week">
+      <div className="upcoming-interviews__calendar" aria-label={calendarLabel}>
         {calendarDays.map((day) => (
           <div
-            key={day.date}
+            key={day.key}
             className={[
               'upcoming-interviews__calendar-day',
               day.isActive ? 'upcoming-interviews__calendar-day--active' : '',
@@ -72,27 +157,7 @@ export const UpcomingInterviews = () => {
         ))}
       </div>
 
-      <ul className="upcoming-interviews__list">
-        {interviews.map((interview) => (
-          <li key={interview.id} className="upcoming-interviews__item">
-            <div className="upcoming-interviews__item-header">
-              <p className="upcoming-interviews__item-company">{interview.company}</p>
-              <p className="upcoming-interviews__item-role">{interview.role}</p>
-            </div>
-
-            <div className="upcoming-interviews__item-meta">
-              <span>
-                <ClockIcon aria-hidden="true" />
-                {interview.date} · {interview.time}
-              </span>
-              <span>
-                {interview.type === 'Virtual' ? <VideoCameraIcon aria-hidden="true" /> : <MapPinIcon aria-hidden="true" />}
-                {interview.type === 'Virtual' ? interview.location : `${interview.type} · ${interview.location}`}
-              </span>
-            </div>
-          </li>
-        ))}
-      </ul>
+      {listContent()}
     </section>
   )
 }

--- a/frontend/src/hooks/useUpcomingInterviews.ts
+++ b/frontend/src/hooks/useUpcomingInterviews.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import { get } from '../api/client'
+import type { UpcomingInterview } from '../types'
+
+const UPCOMING_INTERVIEWS_QUERY_KEY = ['interviews', 'upcoming'] as const
+
+export const useUpcomingInterviews = () =>
+  useQuery({
+    queryKey: UPCOMING_INTERVIEWS_QUERY_KEY,
+    queryFn: () => get<UpcomingInterview[]>('/interviews/upcoming'),
+    staleTime: 30 * 1000,
+  })
+
+export type UseUpcomingInterviewsResult = ReturnType<typeof useUpcomingInterviews>
+export { UPCOMING_INTERVIEWS_QUERY_KEY }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -45,3 +45,12 @@ export interface PaginatedResponse<T> {
     total: number
   }
 }
+
+export interface UpcomingInterview {
+  id: number
+  company: string
+  role: string
+  scheduled_at: string
+  format: 'virtual' | 'in_person'
+  location: string
+}


### PR DESCRIPTION
## Summary
- add an interviews table, model, resource, controller, and seeder plus an API route for upcoming interviews
- consume the new endpoint in the UpcomingInterviews widget and remove the hard-coded calendar label and data
- add UI placeholders to cover loading, empty, and error states when interview data is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de4aa708bc83259b361789ca76241b