### PR TITLE
Revamp job outcome board with detailed views

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -325,6 +325,10 @@
   transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
 }
 
+.kanban__column--outcome {
+  justify-content: flex-start;
+}
+
 .kanban__column--over {
   border-color: var(--color-brand);
   box-shadow: 0 20px 40px rgba(99, 102, 241, 0.2);
@@ -437,6 +441,142 @@
 .kanban__card-meta span:first-of-type::before {
   content: "";
   margin-right: 0;
+}
+
+.status-detail {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: var(--shadow-card);
+  border: 1px solid var(--color-border);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.status-detail__placeholder {
+  display: grid;
+  place-items: center;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px dashed var(--color-border);
+  color: var(--color-text-muted);
+  box-shadow: var(--shadow-card);
+  min-height: 12rem;
+}
+
+.status-detail__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.status-detail__eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--color-brand);
+}
+
+.status-detail__description {
+  margin: 0;
+  max-width: 48ch;
+  color: var(--color-text-muted);
+  line-height: 1.6;
+}
+
+.status-detail__action {
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-weight: 600;
+  padding: 0.6rem 1.25rem;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease, transform 160ms ease;
+}
+
+.status-detail__action:hover,
+.status-detail__action:focus-visible {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: var(--color-border-strong);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.status-detail__content {
+  display: flex;
+  min-height: 0;
+}
+
+.status-detail__content .kanban__column {
+  flex: 1;
+}
+
+.outcome-summary {
+  display: grid;
+  gap: 0.5rem;
+  align-items: center;
+  justify-items: start;
+  padding: 1.75rem 1.5rem;
+  border-radius: 1rem;
+  border: 1px dashed var(--color-border);
+  background: rgba(99, 102, 241, 0.08);
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.outcome-summary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+}
+
+.outcome-summary:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 4px;
+}
+
+.outcome-summary--accepted {
+  background: linear-gradient(130deg, rgba(45, 212, 191, 0.32), rgba(16, 185, 129, 0.12));
+  border-color: rgba(16, 185, 129, 0.35);
+  color: #065f46;
+}
+
+.outcome-summary--accepted .outcome-summary__label {
+  color: rgba(6, 95, 70, 0.7);
+}
+
+.outcome-summary--rejected {
+  background: linear-gradient(130deg, rgba(248, 113, 113, 0.35), rgba(239, 68, 68, 0.15));
+  border-color: rgba(220, 38, 38, 0.35);
+  color: #7f1d1d;
+}
+
+.outcome-summary--rejected .outcome-summary__label {
+  color: rgba(127, 29, 29, 0.7);
+}
+
+.kanban__column--outcome.kanban__column--over .outcome-summary {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 44px rgba(99, 102, 241, 0.22);
+  border-color: var(--color-brand);
+}
+
+.outcome-summary__count {
+  font-size: clamp(2.4rem, 3.5vw, 2.8rem);
+  line-height: 1;
+}
+
+.outcome-summary__label {
+  font-size: 0.95rem;
+  font-weight: 500;
 }
 
 @media (max-width: 1200px) {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,21 @@
 import './App.css'
 import { HeroHeader } from './components/dashboard/HeroHeader'
 import { ApplicationsBoard } from './components/dashboard/ApplicationsBoard'
+import { StatusDetailPage } from './pages/StatusDetailPage'
+import { useNavigation } from './navigation/NavigationProvider'
 
 export default function App() {
+  const { pathname } = useNavigation()
+  const isStatusView = pathname.startsWith('/status/')
+  const statusSlug = isStatusView ? decodeURIComponent(pathname.replace('/status/', '').replace(/^\/+/, '')) : null
+
   return (
     <div className="app-shell">
       <HeroHeader />
 
       <main className="dashboard-grid">
         <div className="dashboard-grid__column dashboard-grid__column--center">
-          <ApplicationsBoard />
+          {isStatusView && statusSlug ? <StatusDetailPage slug={statusSlug} /> : <ApplicationsBoard />}
         </div>
       </main>
     </div>

--- a/frontend/src/components/Column.tsx
+++ b/frontend/src/components/Column.tsx
@@ -2,13 +2,16 @@ import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import type { JobStatus, Job } from '../types'
 import { JobCard } from './JobCard'
+import { useNavigation } from '../navigation/NavigationProvider'
 
 interface ColumnProps {
   status: JobStatus
   jobs: Job[]
+  showOutcomeSummary?: boolean
 }
 
-export const Column = ({ status, jobs }: ColumnProps) => {
+export const Column = ({ status, jobs, showOutcomeSummary = true }: ColumnProps) => {
+  const { navigate } = useNavigation()
   const { isOver, setNodeRef } = useDroppable({
     id: `column-${status.id}`,
     data: {
@@ -16,6 +19,38 @@ export const Column = ({ status, jobs }: ColumnProps) => {
       statusId: status.id,
     },
   })
+
+  const isOutcomeColumn =
+    showOutcomeSummary && (status.slug === 'accepted' || status.slug === 'rejected')
+
+  if (isOutcomeColumn) {
+    const outcomeVariant = status.slug === 'accepted' ? 'accepted' : 'rejected'
+
+    return (
+      <div
+        ref={setNodeRef}
+        className={`kanban__column kanban__column--outcome${isOver ? ' kanban__column--over' : ''}`}
+        role="listitem"
+        aria-label={`${status.name} column`}
+      >
+        <header className="kanban__column-header">
+          <h3>{status.name}</h3>
+          <span className="kanban__column-count">{jobs.length}</span>
+        </header>
+
+        <button
+          type="button"
+          className={`outcome-summary outcome-summary--${outcomeVariant}`}
+          onClick={() => navigate(`/status/${status.slug}`)}
+        >
+          <span className="outcome-summary__count" aria-live="polite">
+            {jobs.length}
+          </span>
+          <span className="outcome-summary__label">View details</span>
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {DndContext} from '@dnd-kit/core'
 import {AppThemeProvider} from './theme/AppThemeProvider.tsx'
+import {NavigationProvider} from './navigation/NavigationProvider.tsx'
 import './index.css'
 import App from './App.tsx'
 
@@ -12,9 +13,11 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <AppThemeProvider>
-        <DndContext>
-          <App />
-        </DndContext>
+        <NavigationProvider>
+          <DndContext>
+            <App />
+          </DndContext>
+        </NavigationProvider>
       </AppThemeProvider>
     </QueryClientProvider>
   </StrictMode>,

--- a/frontend/src/navigation/NavigationProvider.tsx
+++ b/frontend/src/navigation/NavigationProvider.tsx
@@ -1,0 +1,55 @@
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+
+interface NavigationContextValue {
+  pathname: string
+  navigate: (path: string) => void
+  goBack: () => void
+}
+
+const NavigationContext = createContext<NavigationContextValue | null>(null)
+
+export const NavigationProvider = ({ children }: { children: ReactNode }) => {
+  const [pathname, setPathname] = useState(() => window.location.pathname)
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setPathname(window.location.pathname)
+    }
+
+    window.addEventListener('popstate', handlePopState)
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState)
+    }
+  }, [])
+
+  const navigate = useCallback((nextPath: string) => {
+    if (nextPath === window.location.pathname) {
+      return
+    }
+
+    window.history.pushState({}, '', nextPath)
+    setPathname(nextPath)
+  }, [])
+
+  const goBack = useCallback(() => {
+    window.history.back()
+  }, [])
+
+  const value = useMemo<NavigationContextValue>(
+    () => ({ pathname, navigate, goBack }),
+    [pathname, navigate, goBack],
+  )
+
+  return <NavigationContext.Provider value={value}>{children}</NavigationContext.Provider>
+}
+
+export const useNavigation = () => {
+  const context = useContext(NavigationContext)
+
+  if (!context) {
+    throw new Error('useNavigation must be used within a NavigationProvider')
+  }
+
+  return context
+}

--- a/frontend/src/pages/StatusDetailPage.tsx
+++ b/frontend/src/pages/StatusDetailPage.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from 'react'
+import { Column } from '../components/Column'
+import { useJobStatuses } from '../hooks/useJobStatuses'
+import { useJobs } from '../hooks/useJobs'
+import { useNavigation } from '../navigation/NavigationProvider'
+
+interface StatusDetailPageProps {
+  slug: string
+}
+
+export const StatusDetailPage = ({ slug }: StatusDetailPageProps) => {
+  const { navigate } = useNavigation()
+  const jobStatusesQuery = useJobStatuses()
+  const jobsQuery = useJobs()
+
+  const status = useMemo(
+    () => jobStatusesQuery.data?.find((item) => item.slug === slug),
+    [jobStatusesQuery.data, slug],
+  )
+
+  const jobs = jobsQuery.data?.data ?? []
+
+  const statusJobs = useMemo(
+    () => (status ? jobs.filter((job) => job.job_status_id === status.id) : []),
+    [jobs, status],
+  )
+
+  if (jobStatusesQuery.isLoading || jobsQuery.isLoading) {
+    return <div className="status-detail__placeholder">Loading jobs…</div>
+  }
+
+  if (!status) {
+    return (
+      <section className="status-detail" aria-live="polite">
+        <header className="status-detail__header">
+          <div>
+            <p className="status-detail__eyebrow">Status overview</p>
+            <h2>We couldn't find that status</h2>
+            <p className="status-detail__description">
+              The status you're trying to view doesn't exist. Return to the main board to continue tracking your search.
+            </p>
+          </div>
+
+          <button type="button" className="status-detail__action" onClick={() => navigate('/')}>Back to board</button>
+        </header>
+      </section>
+    )
+  }
+
+  return (
+    <section className="status-detail" aria-labelledby="status-detail-heading">
+      <header className="status-detail__header">
+        <div>
+          <p className="status-detail__eyebrow">Status overview</p>
+          <h2 id="status-detail-heading">{status.name}</h2>
+          <p className="status-detail__description">
+            Review every job that has been marked as {status.name.toLowerCase()}. Drag a card back to a pipeline stage if you need to
+            reopen the conversation.
+          </p>
+        </div>
+
+        <button type="button" className="status-detail__action" onClick={() => navigate('/')}>
+          Back to board
+        </button>
+      </header>
+
+      <div className="status-detail__content">
+        <Column status={status} jobs={statusJobs} showOutcomeSummary={false} />
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- add a lightweight navigation provider to switch between the board and status detail pages
- collapse accepted and rejected columns into summary cards that link to dedicated job lists
- style the new outcome summaries and detail view to match the refreshed layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de5235082c8325916e31aa8f2e67f5